### PR TITLE
Build on npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "dist/debugger.js",
   "scripts": {
     "docs": "esdoc",
+    "prepare": "npm run build",
     "build": "webpack --config webpack/webpack.config.js",
     "start": "node ./webpack/dev-server.js",
     "test": "mocha-webpack --webpack-config webpack/webpack.config-test.js --recursive",


### PR DESCRIPTION
As discussed. This should run the build when installed locally without arguments.