### PR TITLE
Clean up various selectors

### DIFF
--- a/lib/data/sagas/index.js
+++ b/lib/data/sagas/index.js
@@ -25,10 +25,10 @@ export function *declare(node) {
 function *tickSaga() {
   let {tree, id: treeId} = yield select(data.views.ast.current);
   let {node, pointer} = yield select(data.views.ast.next);
-  let scopes = yield select(data.scopes.tables.current);
-  let definitions = yield select(data.scopes.tables.inlined.current);
+  let scopes = yield select(data.info.scopes);
+  let definitions = yield select(data.views.scopes.inlined);
 
-  let stack = yield select(data.current.stack);
+  let stack = yield select(data.next.stack);
   if (!stack) {
     return;
   }

--- a/lib/evm/selectors/index.js
+++ b/lib/evm/selectors/index.js
@@ -80,37 +80,18 @@ const evm = createSelectorTree({
      *
      * evm state info: as of last operation, before op defined in step
      */
-    state: createLeaf(
-      [trace.step], ({depth, error, gas, memory, stack, storage}) =>
-        ({depth, error, gas, memory, stack, storage})
-    ),
-
-    /**
-     * evm.current.stack
-     *
-     * stack data
-     */
-    stack: createLeaf(
-      [trace.step], (step) => step.stack
-    ),
-
-    /**
-     * evm.current.memory
-     *
-     * memory data
-     */
-    memory: createLeaf(
-      [trace.step], (step) => step.memory
-    ),
-
-    /**
-     * evm.current.storage,
-     *
-     * storage data
-     */
-    storage: createLeaf(
-      [trace.step], (step) => step.storage
-    )
+    state: Object.assign({}, ...(
+      [
+        "depth",
+        "error",
+        "gas",
+        "memory",
+        "stack",
+        "storage"
+      ].map( (param) => ({
+        [param]: createLeaf([trace.step], (step) => step[param])
+      }))
+    ))
   },
 
   /**

--- a/lib/solidity/selectors/index.js
+++ b/lib/solidity/selectors/index.js
@@ -7,6 +7,20 @@ import CodeUtils from "truffle-code-utils";
 
 import evm from "lib/evm/selectors";
 
+function getSourceRange(instruction = {}) {
+  return {
+    start: instruction.start || 0,
+    length: instruction.length || 0,
+    lines: instruction.range || {
+      start: {
+        line: 0, column: 0
+      },
+      end: {
+        line: 0, column: 0
+      }
+    }
+  };
+}
 
 let solidity = createSelectorTree({
   /**
@@ -145,25 +159,7 @@ let solidity = createSelectorTree({
     /**
      * solidity.next.sourceRange
      */
-    sourceRange: createLeaf(
-      ["./instruction"],
-
-      (instruction) => {
-        instruction = instruction || {};
-        return {
-          start: instruction.start || 0,
-          length: instruction.length || 0,
-          lines: instruction.range || {
-            start: {
-              line: 0, column: 0
-            },
-            end: {
-              line: 0, column: 0
-            }
-          }
-        };
-      }
-    ),
+    sourceRange: createLeaf(["./instruction"], getSourceRange),
 
     /**
      * solidity.next.isMultiline


### PR DESCRIPTION
Since the upcoming release eliminates the `context` app-module (a breaking change if anyone is using this library), figured I'd push the envelope and add more breaking changes.

- Remove `data.scopes.tables`, since changes in #48 make the notion of "data tables" obsolete
- Remove `evm.current.{state|memory|storage}`, as these are unused
- Make `evm.current.state` behave like `evm.next.state`, i.e., compose leaf selectors for each "state" var (`stack`, `gas`, `error`, etc.)
- Random bits of code cleanup