### PR TITLE
Skip variable declarations when stepping

### DIFF
--- a/lib/controller/sagas/index.js
+++ b/lib/controller/sagas/index.js
@@ -11,7 +11,7 @@ import * as actions from "../actions";
 
 import controller from "../selectors";
 
-const controlSagas = {
+const CONTROL_SAGAS = {
   [actions.ADVANCE]: advance,
   [actions.STEP_NEXT]: stepNext,
   [actions.STEP_OVER]: stepOver,
@@ -29,9 +29,9 @@ const SKIPPED_TYPES = new Set([
 export function* saga() {
   while (true) {
     debug("waiting for control action");
-    let action = yield take(Object.keys(controlSagas));
+    let action = yield take(Object.keys(CONTROL_SAGAS));
     debug("got control action");
-    let saga = controlSagas[action.type];
+    let saga = CONTROL_SAGAS[action.type];
 
     yield put(actions.beginStep(action.type));
 

--- a/lib/controller/sagas/index.js
+++ b/lib/controller/sagas/index.js
@@ -20,6 +20,12 @@ const controlSagas = {
   [actions.CONTINUE_UNTIL]: continueUntil
 };
 
+/** AST node types that are skipped to filter out some noise */
+const SKIPPED_TYPES = new Set([
+  "ContractDefinition",
+  "VariableDeclaration",
+]);
+
 export function* saga() {
   while (true) {
     debug("waiting for control action");
@@ -67,8 +73,7 @@ function* stepNext () {
 
     // if the next step's source range is still the same, keep going
   } while (
-    // HACK - just skip over ContractDefinition nodes
-    next.node.nodeType == "ContractDefinition" ||
+    SKIPPED_TYPES.has(next.node.nodeType) ||
 
     next.sourceRange.start == startingRange.start &&
     next.sourceRange.length == startingRange.length


### PR DESCRIPTION
`solc` includes them in the sourcemapping because it takes real work... but it's quite noisy for most cases.