### PR TITLE
Fix unhandled exception for unknown line and column mappings

### DIFF
--- a/lib/solidity/selectors/index.js
+++ b/lib/solidity/selectors/index.js
@@ -100,7 +100,8 @@ let solidity = createSelectorTree({
           instruction.index = instructionIndex;
 
           if (sourceMapInstruction) {
-            var lineAndColumnMapping = lineAndColumnMappings[sourceMapInstruction.file];
+            var lineAndColumnMapping =
+              lineAndColumnMappings[sourceMapInstruction.file] || {};
 
             instruction.jump = sourceMapInstruction.jump;
             instruction.start = sourceMapInstruction.start;


### PR DESCRIPTION
Ref: #56 

Provide a default value for `lineAndColumnMapping` to prevent the unhandled exception described in ref. issue.

Root cause here unknown, but these unhandled exceptions gotta stop.