### PR TITLE
Fix confusing distinction between `next` and `current`

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ session.stepInfo();
 let { ast, data, evm, solidity, trace } = Debugger.selectors;
 
 let variables = session.view(data.identifiers.native.current);
-let sourceRange = session.view(solidity.next.sourceRange);
+let sourceRange = session.view(solidity.current.sourceRange);
 ```
 
 ### Useful API Docs References

--- a/lib/ast/selectors/index.js
+++ b/lib/ast/selectors/index.js
@@ -34,7 +34,7 @@ const ast = createSelectorTree({
      * ast for current source
      */
     tree: createLeaf(
-      [solidity.next.source], ({ast}) => ast
+      [solidity.current.source], ({ast}) => ast
     ),
 
     /**
@@ -43,32 +43,26 @@ const ast = createSelectorTree({
      * source ID
      */
     index: createLeaf(
-      [solidity.next.source], ({id}) => id
-    )
-  },
-
-  /**
-   * ast.next
-   */
-  next: {
+      [solidity.current.source], ({id}) => id
+    ),
 
     /**
-     * ast.next.pointer
+     * ast.current.pointer
      *
-     * jsonpointer for next ast node
+     * jsonpointer for current ast node
      */
     pointer: createLeaf(
-      ["/current/tree", solidity.next.sourceRange], (ast, range) =>
+      ["./tree", solidity.current.sourceRange], (ast, range) =>
         findRange(ast, range.start, range.length)
     ),
 
     /**
-     * ast.next.node
+     * ast.current.node
      *
-     * next ast node to execute
+     * current ast node to execute
      */
     node: createLeaf(
-      ["/current/tree", "./pointer"], (ast, pointer) =>
+      ["./tree", "./pointer"], (ast, pointer) =>
         jsonpointer.get(ast, pointer)
     ),
 

--- a/lib/ast/selectors/index.js
+++ b/lib/ast/selectors/index.js
@@ -52,7 +52,7 @@ const ast = createSelectorTree({
      * jsonpointer for current ast node
      */
     pointer: createLeaf(
-      ["./tree", solidity.next.sourceRange],
+      ["./tree", solidity.current.sourceRange],
 
       (ast, range) => findRange(ast, range.start, range.length)
     ),

--- a/lib/controller/selectors/index.js
+++ b/lib/controller/selectors/index.js
@@ -29,37 +29,31 @@ const controller = createSelectorTree({
     /**
      * controller.current.executionContext
      */
-    executionContext: createLeaf([evm.current.call], identity)
-  },
-
-  /**
-   * controller.next
-   */
-  next: {
+    executionContext: createLeaf([evm.current.call], identity),
 
     /**
-     * controller.next.willJump
+     * controller.current.willJump
      */
-    willJump: createLeaf([evm.next.step.isJump], identity),
+    willJump: createLeaf([evm.current.step.isJump], identity),
 
     /**
-     * controller.next.location
+     * controller.current.location
      */
     location: {
       /**
-       * controller.next.location.sourceRange
+       * controller.current.location.sourceRange
        */
-      sourceRange: createLeaf([solidity.next.sourceRange], identity),
+      sourceRange: createLeaf([solidity.current.sourceRange], identity),
 
       /**
-       * controller.next.location.node
+       * controller.current.location.node
        */
-      node: createLeaf([ast.next.node], identity),
+      node: createLeaf([ast.current.node], identity),
 
       /**
-       * controller.next.location.isMultiline
+       * controller.current.location.isMultiline
        */
-      isMultiline: createLeaf([solidity.next.isMultiline], identity),
+      isMultiline: createLeaf([solidity.current.isMultiline], identity),
     }
   }
 });

--- a/lib/data/sagas/index.js
+++ b/lib/data/sagas/index.js
@@ -23,8 +23,13 @@ export function *declare(node) {
 }
 
 function *tickSaga() {
-  let {tree, id: treeId} = yield select(data.views.ast.current);
-  let {node, pointer} = yield select(data.views.ast.next);
+  let {
+    tree,
+    id: treeId,
+    node,
+    pointer
+  } = yield select(data.views.ast);
+
   let scopes = yield select(data.info.scopes);
   let definitions = yield select(data.views.scopes.inlined);
 

--- a/lib/data/sagas/index.js
+++ b/lib/data/sagas/index.js
@@ -33,7 +33,7 @@ function *tickSaga() {
   let scopes = yield select(data.info.scopes);
   let definitions = yield select(data.views.scopes.inlined);
 
-  let stack = yield select(data.next.stack);
+  let stack = yield select(data.next.state.stack);
   if (!stack) {
     return;
   }

--- a/lib/data/selectors/index.js
+++ b/lib/data/selectors/index.js
@@ -38,15 +38,9 @@ const data = createSelectorTree({
    * data.views
    */
   views: {
-    ast: {
-      current: createLeaf(
-        [ast.current.tree, ast.current.index], (tree, id) => ({tree, id})
-      ),
-
-      next: createLeaf(
-        [ast.next.node, ast.next.pointer], (node, pointer) => ({node, pointer})
-      )
-    },
+    ast: createLeaf(
+      [ast.current], (tree) => tree
+    ),
 
     /**
      * data.views.scopes
@@ -99,23 +93,28 @@ const data = createSelectorTree({
   },
 
   /**
-   * data.next
+   * data.current
    */
-  next: {
-
+  current: {
     /**
      *
-     * data.next.scope
+     * data.current.scope
      */
     scope: {
 
       /**
-       * data.next.scope.id
+       * data.current.scope.id
        */
       id: createLeaf(
-        [ast.next.node], (node) => node.id
+        [ast.current.node], (node) => node.id
       )
     },
+  },
+
+  /**
+   * data.next
+   */
+  next: {
 
     /**
      * data.next.stack
@@ -174,11 +173,12 @@ const data = createSelectorTree({
       [
         "/views/scopes/inlined",
         "/proc/assignments",
+        "/current/scope",
         "/next"
       ],
 
-      (scopes, assignments, next) => {
-        let {scope, stack, memory, storage} = next;
+      (scopes, assignments, scope, next) => {
+        let { stack, memory, storage } = next;
         let cur = scope.id;
         let variables = {};
 

--- a/lib/debugger.js
+++ b/lib/debugger.js
@@ -81,7 +81,7 @@ export default class Debugger {
    * Debugger.selectors.ast.current.tree
    *
    * @example
-   * Debugger.selectors.solidity.next.instruction
+   * Debugger.selectors.solidity.current.instruction
    *
    * @example
    * Debugger.selectors.trace.steps

--- a/lib/evm/sagas/index.js
+++ b/lib/evm/sagas/index.js
@@ -44,19 +44,19 @@ export function* callstackSaga () {
     yield take(TICK);
     debug("got TICK");
 
-    if (yield select(evm.next.step.isCall)) {
+    if (yield select(evm.current.step.isCall)) {
       debug("got call");
-      let address = yield select(evm.next.step.callAddress);
+      let address = yield select(evm.current.step.callAddress);
 
       yield put(actions.call(address));
 
-    } else if (yield select(evm.next.step.isCreate)) {
+    } else if (yield select(evm.current.step.isCreate)) {
       debug("got create");
-      let binary = yield select(evm.next.step.createBinary);
+      let binary = yield select(evm.current.step.createBinary);
 
       yield put(actions.create(binary));
 
-    } else if (yield select(evm.next.step.isHalting)) {
+    } else if (yield select(evm.current.step.isHalting)) {
       debug("got return");
       yield put(actions.returnCall());
     }

--- a/lib/evm/selectors/index.js
+++ b/lib/evm/selectors/index.js
@@ -231,7 +231,9 @@ const evm = createSelectorTree({
       ].map( (param) => ({
         [param]: createLeaf([trace.next], (step) => step[param])
       }))
-    ))
+    )),
+
+    step: createStepSelectors(trace.next, "./state")
   }
 });
 

--- a/lib/evm/selectors/index.js
+++ b/lib/evm/selectors/index.js
@@ -16,7 +16,7 @@ function createStepSelectors(step, state = null) {
     /**
      * .trace
      *
-     * trace step info related to next evm operation
+     * trace step info related to operation
      */
     trace: createLeaf(
       [step], ({gasCost, op, pc}) => ({gasCost, op, pc})
@@ -41,7 +41,7 @@ function createStepSelectors(step, state = null) {
     /**
      * .isCall
      *
-     * whether the next opcode will switch to another calling context
+     * whether the opcode will switch to another calling context
      */
     isCall: createLeaf(
       ["./trace"], (step) => step.op == "CALL" || step.op == "DELEGATECALL"
@@ -57,7 +57,7 @@ function createStepSelectors(step, state = null) {
     /**
      * .isHalting
      *
-     * whether the next instruction halts or returns from a calling context
+     * whether the instruction halts or returns from a calling context
      */
     isHalting: createLeaf(
       ["./trace"], (step) => step.op == "STOP" || step.op == "RETURN"
@@ -202,7 +202,12 @@ const evm = createSelectorTree({
       ].map( (param) => ({
         [param]: createLeaf([trace.step], (step) => step[param])
       }))
-    ))
+    )),
+
+    /**
+     * evm.current.step
+     */
+    step: createStepSelectors(trace.step, "./state")
   },
 
   /**
@@ -226,12 +231,7 @@ const evm = createSelectorTree({
       ].map( (param) => ({
         [param]: createLeaf([trace.next], (step) => step[param])
       }))
-    )),
-
-    /**
-     * evm.next.step
-     */
-    step: createStepSelectors(trace.step, "/current/state")
+    ))
   }
 });
 

--- a/lib/solidity/sagas/index.js
+++ b/lib/solidity/sagas/index.js
@@ -21,11 +21,11 @@ function* functionDepthSaga () {
   while (true) {
     yield take(TICK);
     debug("got TICK");
-    let instruction = yield select(solidity.next.instruction);
+    let instruction = yield select(solidity.current.instruction);
     debug("instruction: %o", instruction);
 
-    if (yield select(solidity.next.willJump)) {
-      let jumpDirection = yield select(solidity.next.jumpDirection);
+    if (yield select(solidity.current.willJump)) {
+      let jumpDirection = yield select(solidity.current.jumpDirection);
 
 
       yield put(actions.jump(jumpDirection));

--- a/lib/solidity/selectors/index.js
+++ b/lib/solidity/selectors/index.js
@@ -131,25 +131,19 @@ let solidity = createSelectorTree({
         });
         return map;
       }
-    )
-  },
-
-  /**
-   * solidity.next
-   */
-  next: {
+    ),
 
     /**
-     * solidity.next.instruction
+     * solidity.current.instruction
      */
     instruction: createLeaf(
-      ["../current/instructionAtProgramCounter", evm.next.step.programCounter],
+      ["../current/instructionAtProgramCounter", evm.current.step.programCounter],
 
       (map, pc) => map[pc]
     ),
 
     /**
-     * solidity.next.source
+     * solidity.current.source
      */
     source: createLeaf(
       ["/info/sources", "./instruction"],
@@ -158,12 +152,12 @@ let solidity = createSelectorTree({
     ),
 
     /**
-     * solidity.next.sourceRange
+     * solidity.current.sourceRange
      */
     sourceRange: createLeaf(["./instruction"], getSourceRange),
 
     /**
-     * solidity.next.isMultiline
+     * solidity.current.isMultiline
      */
     isMultiline: createLeaf(
       ["./sourceRange"],
@@ -172,12 +166,12 @@ let solidity = createSelectorTree({
     ),
 
     /**
-     * solidity.next.willJump
+     * solidity.current.willJump
      */
-    willJump: createLeaf([evm.next.step.isJump], (isJump) => isJump),
+    willJump: createLeaf([evm.current.step.isJump], (isJump) => isJump),
 
     /**
-     * solidity.next.jumpDirection
+     * solidity.current.jumpDirection
      */
     jumpDirection: createLeaf(
       ["./instruction"], (i = {}) => (i.jump || "-")

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "redux-cli-logger": "^2.0.1",
     "redux-saga": "^0.16.0",
     "remote-redux-devtools": "^0.5.12",
-    "reselect-tree": "^1.1.3",
+    "reselect-tree": "^1.2.0",
     "truffle-code-utils": "^1.1.0",
     "truffle-expect": "0.0.3",
     "truffle-solidity-utils": "^1.1.0",

--- a/test/ast.js
+++ b/test/ast.js
@@ -122,15 +122,15 @@ describe("AST", function() {
       debug("ast: %O", session.view(ast.current.tree));
 
       do {
-        let { start, length } = session.view(solidity.next.sourceRange);
+        let { start, length } = session.view(solidity.current.sourceRange);
         let end = start + length;
 
-        let node = session.view(ast.next.node);
+        let node = session.view(ast.current.node);
 
         let [ nodeStart, nodeLength ] = getRange(node);
         let nodeEnd = nodeStart + nodeLength;
 
-        let pointer = session.view(ast.next.pointer);
+        let pointer = session.view(ast.current.pointer);
 
         assert.isAtMost(
           nodeStart, start,

--- a/test/solidity.js
+++ b/test/solidity.js
@@ -110,7 +110,7 @@ describe("Solidity Debugging", function() {
       session.continueUntil(breakpoint);
 
       if (!session.finished) {
-        let range = await session.view(solidity.next.sourceRange);
+        let range = await session.view(solidity.current.sourceRange);
         assert.equal(range.lines.start.line, 16);
 
         breakpointStopped = true;


### PR DESCRIPTION
Mostly related to selector namespaces.

Enforce the notion that `current` always refers to the _current trace step_, and `next` always refers to the trace step after that.

Currently, lots of selectors (e.g. `solidity.next.sourceRange`) use the term "next" to mean "upcoming". This is confusing because in some places (e.g. `evm.next.state`), `next` refers to a different step in the trace.

This PR opens up the various `next` namespaces so that they can refer to information about the next step trace. (e.g. so that `solidity.current.sourceRange` can be compared to `solidity.next.sourceRange`)