### PR TITLE
Skip data interpretation at invalid points of execution

### DIFF
--- a/lib/data/sagas/index.js
+++ b/lib/data/sagas/index.js
@@ -44,6 +44,17 @@ function *tickSaga() {
   switch (node.nodeType) {
 
     case "FunctionDefinition":
+      // stack is only ready for interpretation after the last step of each
+      // source range
+      //
+      // the data module always looks at the result of a particular opcode
+      // (i.e., the following trace step's stack/memory/storage), so this
+      // asserts that the _current_ operation is the final one before
+      // proceeding
+      if (!(yield select(data.views.atLastInstructionForSourceRange))) {
+        break;
+      }
+
       parameters = node.parameters.parameters
         .map( (p, i) => `${pointer}/parameters/parameters/${i}` );
 

--- a/lib/data/selectors/index.js
+++ b/lib/data/selectors/index.js
@@ -42,6 +42,10 @@ const data = createSelectorTree({
       [ast.current], (tree) => tree
     ),
 
+    atLastInstructionForSourceRange: createLeaf(
+      [solidity.current.isSourceRangeFinal], (final) => final
+    ),
+
     /**
      * data.views.scopes
      */
@@ -108,7 +112,7 @@ const data = createSelectorTree({
       id: createLeaf(
         [ast.current.node], (node) => node.id
       )
-    },
+    }
   },
 
   /**

--- a/lib/solidity/selectors/index.js
+++ b/lib/solidity/selectors/index.js
@@ -137,7 +137,7 @@ let solidity = createSelectorTree({
      * solidity.current.instruction
      */
     instruction: createLeaf(
-      ["../current/instructionAtProgramCounter", evm.current.step.programCounter],
+      ["./instructionAtProgramCounter", evm.current.step.programCounter],
 
       (map, pc) => map[pc]
     ),
@@ -155,6 +155,32 @@ let solidity = createSelectorTree({
      * solidity.current.sourceRange
      */
     sourceRange: createLeaf(["./instruction"], getSourceRange),
+
+    /**
+     * solidity.current.isSourceRangeFinal
+     */
+    isSourceRangeFinal: createLeaf(
+      [
+        "./instructionAtProgramCounter",
+        evm.current.step.programCounter,
+        evm.next.step.programCounter
+      ],
+
+      (map, current, next) => {
+        if (!map[next]) {
+          return true;
+        }
+
+        current = map[current];
+        next = map[next];
+
+        return (
+          current.start != next.start ||
+          current.length != next.length ||
+          current.file != next.file
+        );
+      }
+    ),
 
     /**
      * solidity.current.isMultiline


### PR DESCRIPTION
Currently, data is read from stack and interpreted at every operation. Lots of those operations are responsible for preparing the data to be meaningful at the Solidity level, so we really only ought to read data when it's Solidity-meaningful.

This adds a few selectors to ensure data is processed at the end of a given block of operations, ie, the final operation for a given source range.