### PR TITLE
Improve edge case handling for source location lookup

### DIFF
--- a/lib/ast/selectors/index.js
+++ b/lib/ast/selectors/index.js
@@ -58,8 +58,9 @@ const ast = createSelectorTree({
      * jsonpointer for next ast node
      */
     pointer: createLeaf(
-      ["/current/tree", solidity.next.sourceRange], (ast, range) =>
-        findRange(ast, range.start, range.length)
+      ["/current/tree", solidity.next.sourceRange],
+
+      (ast, range) => findRange(ast, range.start, range.length)
     ),
 
     /**
@@ -69,7 +70,9 @@ const ast = createSelectorTree({
      */
     node: createLeaf(
       ["/current/tree", "./pointer"], (ast, pointer) =>
-        jsonpointer.get(ast, pointer)
+        (pointer)
+          ? jsonpointer.get(ast, pointer)
+          : jsonpointer.get(ast, "")
     ),
 
   }

--- a/lib/controller/sagas/index.js
+++ b/lib/controller/sagas/index.js
@@ -73,6 +73,7 @@ function* stepNext () {
 
     // if the next step's source range is still the same, keep going
   } while (
+    !next.node ||
     SKIPPED_TYPES.has(next.node.nodeType) ||
 
     next.sourceRange.start == startingRange.start &&

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "fs-extra": "^4.0.2",
     "ganache-cli": "^6.1.0-beta.4",
     "mocha": "^4.0.1",
-    "mocha-webpack": "^1.0.1",
+    "mocha-webpack": "^1.1.0",
     "remotedev-server": "^0.2.4",
     "truffle-artifactor": "^3.0.0",
     "truffle-box": "^1.0.3",

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,8 +1,6 @@
 import debugModule from "debug";
 const debug = debugModule("test:helpers");
 
-import "source-map-support/register";
-
 import path from "path";
 import fs from "fs-extra";
 import async from "async";

--- a/webpack/webpack.config-test.js
+++ b/webpack/webpack.config-test.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const webpack = require('webpack');
 const merge = require('webpack-merge');
+const WriteFilePlugin = require('write-file-webpack-plugin');
 
 const commonConfig = require('./webpack.config-common.js');
 
@@ -24,5 +25,7 @@ module.exports = merge(commonConfig, {
     new webpack.DefinePlugin({
       'process.env.NODE_ENV': JSON.stringify('test')
     }),
+
+    new WriteFilePlugin(),
   ],
 });


### PR DESCRIPTION
Required for trufflesuite/truffle#897

Background: solc's sourcemaps can refer to file index `-1`, which isn't handled by the debugger right now. Discovered this with v0.4.22, which seems to use that index more often.

Generally, this adds more well-formed defaults in place of `undefined`, and notably skips over undefined nodes when stepping next.

Also: fix mocha-webpack source maps