### PR TITLE
Support unresolved link references in contract bytecode

### DIFF
--- a/lib/evm/actions/index.js
+++ b/lib/evm/actions/index.js
@@ -7,10 +7,10 @@ export function addContext(contractName, binary) {
 }
 
 export const ADD_INSTANCE = "EVM_ADD_INSTANCE";
-export function addInstance(address, binary) {
+export function addInstance(address, context, binary) {
   return {
     type: ADD_INSTANCE,
-    address, binary
+    address, context, binary
   }
 }
 

--- a/lib/evm/reducers.js
+++ b/lib/evm/reducers.js
@@ -52,11 +52,10 @@ const DEFAULT_INSTANCES = {
 function instances(state = DEFAULT_INSTANCES, action) {
   switch (action.type) {
     /*
-     * Adding a new address (with binary)
+     * Adding a new address for context
      */
     case actions.ADD_INSTANCE:
-      let { address, binary } = action;
-      let context = keccak256(binary);
+      let { address, context, binary } = action;
 
       // get known addresses for this context
       let otherInstances = state.byContext[context] || [];
@@ -66,7 +65,7 @@ function instances(state = DEFAULT_INSTANCES, action) {
         byAddress: {
           ...state.byAddress,
 
-          [address]: { context }
+          [address]: { context, binary }
         },
 
         byContext: {

--- a/lib/evm/sagas/index.js
+++ b/lib/evm/sagas/index.js
@@ -26,9 +26,13 @@ export function *addContext(contractName, binary) {
  * @return {string} ID (0x-prefixed keccak of binary)
  */
 export function *addInstance(address, binary) {
-  yield put(actions.addInstance(address, binary));
+  let contexts = yield select(evm.info.contexts);
+  let search = yield select(evm.info.binaries.search);
+  let { context } = search(binary);
 
-  return keccak256(binary);
+  yield put(actions.addInstance(address, context, binary));
+
+  return context;
 }
 
 export function* begin({ address, binary }) {

--- a/lib/evm/sagas/index.js
+++ b/lib/evm/sagas/index.js
@@ -26,7 +26,6 @@ export function *addContext(contractName, binary) {
  * @return {string} ID (0x-prefixed keccak of binary)
  */
 export function *addInstance(address, binary) {
-  let contexts = yield select(evm.info.contexts);
   let search = yield select(evm.info.binaries.search);
   let { context } = search(binary);
 

--- a/lib/evm/selectors/index.js
+++ b/lib/evm/selectors/index.js
@@ -194,22 +194,26 @@ const evm = createSelectorTree({
      * evm.current.context
      */
     context: createLeaf(
-      ["./call", "/info/instances", "/info/binaries", "/info/contexts"],
+      ["./call", "/info/instances", "/info/binaries/search", "/info/contexts"],
 
-      ({address, binary}, instances, binaries, contexts) => {
-        var record;
+      ({address, binary}, instances, search, contexts) => {
+        let record;
         if (address) {
           record = instances[address];
+          binary = record.binary
         } else {
-          // trim off possible constructor args, one word at a time
-          // HACK until there's better CREATE semantics
-          while (record === undefined && binary) {
-            record = binaries[binary];
-            binary = binary.slice(0, -(WORD_SIZE * 2));
-          }
+          record = search(binary);
+          debug("record %o", record);
         }
 
-        return contexts[(record || {}).context];
+        let context = contexts[(record || {}).context];
+
+        debug("contexts %o", contexts);
+
+        return {
+          ...context,
+          binary
+        }
       }
     ),
 

--- a/lib/evm/selectors/index.js
+++ b/lib/evm/selectors/index.js
@@ -152,6 +152,9 @@ const evm = createSelectorTree({
       search: createLeaf(['./_'], (binaries) => {
         // HACK ignore link references for search
         // link references come in two forms: with underscores or all zeroes
+        // the underscore format is used by Truffle to reference links by name
+        // zeroes are used by solc directly, as libraries inject their own
+        // address at CREATE-time
         const toRegExp = (binary) =>
           new RegExp(`^${binary.replace(/__.{38}|0{40}/g, ".{40}")}`)
 

--- a/lib/evm/selectors/index.js
+++ b/lib/evm/selectors/index.js
@@ -161,12 +161,10 @@ const evm = createSelectorTree({
             regex: toRegExp(binary)
           }))
 
-        return (binary) => {
-          return matchers
-            .filter( ({ context, regex }) => binary.match(regex) )
-            .map( ({ context }) => ({ context }) )
-            [0] || null;
-        };
+        return (binary) => matchers
+          .filter( ({ context, regex }) => binary.match(regex) )
+          .map( ({ context }) => ({ context }) )
+          [0] || null;
       })
     }
   },
@@ -203,12 +201,9 @@ const evm = createSelectorTree({
           binary = record.binary
         } else {
           record = search(binary);
-          debug("record %o", record);
         }
 
         let context = contexts[(record || {}).context];
-
-        debug("contexts %o", contexts);
 
         return {
           ...context,

--- a/lib/solidity/selectors/index.js
+++ b/lib/solidity/selectors/index.js
@@ -54,7 +54,7 @@ let solidity = createSelectorTree({
     sourceMap: createLeaf(
       [evm.current.context, "/info/sourceMaps"],
 
-      ({context}, sourceMaps) => sourceMaps[context]
+      ({context}, sourceMaps) => sourceMaps[context] || {}
     ),
 
     /**


### PR DESCRIPTION
Ref: #64 

Currently, the debugger looks up known (provided) bytecodes via observed binary values (via `getCode` or `CREATE 0x...`). These actual values are compared against the provided values using a naive string comparison. (For the case of `CREATE`, constructor arguments are truncated off word-by-word until there is a string match)

This PR modifies how that search is performed, and how the current context is represented:
- Use regex search for bytecode, where the regex tolerates all values for link references. This assumes that link references are exactly 40 characters, either all `0`s, or the `__...` syntax.
- Override the reported "current context" value to use the _actual_ binary, not the unresolved provided form.