### PR TITLE
Re-organize identifier selectors

### DIFF
--- a/lib/data/decode/index.js
+++ b/lib/data/decode/index.js
@@ -151,6 +151,7 @@ export function decodeStorageReference(definition, pointer, state, ...args) {
       debug("length %o", length);
 
       let baseSize = utils.storageSize(utils.baseDefinition(definition));
+      debug("baseSize %o", baseSize);
 
       const offset = (i) => Math.floor(i * baseSize / WORD_SIZE);
       const index = (i) => i * baseSize % WORD_SIZE;

--- a/lib/data/decode/storage.js
+++ b/lib/data/decode/storage.js
@@ -28,43 +28,66 @@ export function read(storage, slot, offset = 0) {
 }
 
 /**
- * read <bytes> amount of bytes from storage, starting at some slot
+ * read all bytes in some range.
+ *
+ * parameters `from` and `to` are objects with the following properties:
+ *
+ *   slot - (required) either a bignumber or a "path" array of integer offsets
+ *
+ *     path array values get converted into keccak256 hash as per solidity
+ *     storage allocation method
+ *
+ *     ref: https://solidity.readthedocs.io/en/v0.4.23/miscellaneous.html#layout-of-state-variables-in-storage
+ *     (search "concatenation")
+ *
+ *  offset - (default: 0) slot offset
+ *
+ *  index - (default: 0) byte index in word
+ *
+ * @param from - location (see ^)
+ * @param to - location (see ^). inclusive.
+ * @param length - instead of `to`, number of bytes after `from`
  */
-export function readBytes(storage, slot, length, offset = 0) {
-  let data = new Uint8Array(length);
-
-  let bytesLeft = length;
-  var buffer;
-  for (let i = 0; i < length / WORD_SIZE; i++) {
-    buffer = read(storage, slot, i + offset);
-    if (bytesLeft < WORD_SIZE) {
-      buffer = buffer.slice(0, bytesLeft);
-    }
-    data.set(buffer, i * WORD_SIZE);
-    bytesLeft -= buffer.length;
+export function readRange(storage, {from, to, length}) {
+  if (!length && !to || length && to) {
+    throw new Error("must specify exactly one `to`|`length`");
   }
 
-  debug(
-    "readbytes slot=%o length=%o offset=%o data=%o",
-    slot, length, offset, data
-  );
+  from = {
+    ...from,
+    offset: from.offset || 0
+  };
+
+  if (length) {
+    to = {
+      slot: from.slot,
+      offset: from.offset + Math.floor((from.index + length - 1) / WORD_SIZE),
+      index: (from.index + length - 1) % WORD_SIZE
+    };
+  } else {
+    to = {
+      ...to,
+      offset: to.offset || 0
+    }
+  }
+
+  debug("readRange %o", {from,to});
+
+  const totalWords = to.offset - from.offset + 1;
+  debug("totalWords %o", totalWords);
+
+  let data = new Uint8Array(totalWords * WORD_SIZE);
+
+  for (let i = 0; i < totalWords; i++) {
+    let offset = i + from.offset;
+    data.set(read(storage, from.slot, offset), i * WORD_SIZE);
+  }
+  debug("words %o", data);
+
+  data = data.slice(from.index, (totalWords - 1) * WORD_SIZE + to.index + 1);
+
+  debug("data: %o", data);
 
   return data;
-}
-
-export function readRange(storage, {from, to, length}) {
-  debug("readRange %o", {from,to,length});
-  if (to != undefined) {
-    let trim = to.index - WORD_SIZE + 1;
-
-    return readBytes(
-      storage, from.slot, (to.slot - from.slot + 1) * WORD_SIZE  // round up
-    ).slice(from.index, trim < 0 ? trim : undefined);
-
-  } else {
-    return readBytes(
-      storage, from.slot, length, from.offset
-    ).slice(from.index);
-  }
 }
 

--- a/lib/data/decode/storage.js
+++ b/lib/data/decode/storage.js
@@ -20,8 +20,11 @@ export function read(storage, slot, offset = 0) {
 
   debug("reading slot: %o", utils.toHexString(slot));
 
-  return storage[utils.toHexString(slot, WORD_SIZE)] ||
+  let word = storage[utils.toHexString(slot, WORD_SIZE)] ||
     new Uint8Array(WORD_SIZE);
+
+  debug("word %o", word);
+  return word
 }
 
 /**
@@ -41,11 +44,16 @@ export function readBytes(storage, slot, length, offset = 0) {
     bytesLeft -= buffer.length;
   }
 
+  debug(
+    "readbytes slot=%o length=%o offset=%o data=%o",
+    slot, length, offset, data
+  );
+
   return data;
 }
 
 export function readRange(storage, {from, to, length}) {
-  debug("readRange %o", Array.prototype.slice(arguments, [1]));
+  debug("readRange %o", {from,to,length});
   if (to != undefined) {
     let trim = to.index - WORD_SIZE + 1;
 

--- a/lib/data/decode/utils.js
+++ b/lib/data/decode/utils.js
@@ -67,7 +67,10 @@ export function allocateDeclarations(
     let { from, to, next, children } =
       allocateDeclaration(declaration, refs, slot, index);
 
-    mapping[declaration.id] = { from, to, children, name: declaration.name };
+    mapping[declaration.id] = { from, to, name: declaration.name };
+    if (children !== undefined) {
+      mapping[declaration.id].children = children;
+    }
 
     slot = next.slot;
     index = next.index;

--- a/lib/data/decode/utils.js
+++ b/lib/data/decode/utils.js
@@ -7,6 +7,27 @@ import Web3 from "web3";
 export const WORD_SIZE = 0x20;
 export const MAX_WORD = new BigNumber(2).pow(256).minus(1);
 
+/**
+ * recursively converts big numbers into something nicer to look at
+ */
+export function cleanBigNumbers(value) {
+  if (BigNumber.isBigNumber(value)) {
+    return value.toNumber();
+
+  } else if (value && value.map != undefined) {
+    return value.map( (inner) => cleanBigNumbers(inner) );
+
+  } else if (value && typeof value == "object") {
+    return Object.assign(
+      {}, ...Object.entries(value)
+        .map( ([key, inner]) => ({ [key]: cleanBigNumbers(inner) }) )
+    );
+
+  } else {
+    return value;
+  }
+}
+
 export function typeIdentifier(definition) {
   return definition.typeDescriptions.typeIdentifier;
 }

--- a/lib/data/sagas/index.js
+++ b/lib/data/sagas/index.js
@@ -41,6 +41,10 @@ function *tickSaga() {
   let top = stack.length - 1;
   var parameters, returnParameters, assignments, storageVars;
 
+  if (!node) {
+    return;
+  }
+
   switch (node.nodeType) {
 
     case "FunctionDefinition":

--- a/lib/data/selectors/index.js
+++ b/lib/data/selectors/index.js
@@ -112,7 +112,22 @@ const data = createSelectorTree({
           )
         )
       )
-    }
+    },
+
+    /**
+     * data.views.decoder
+     *
+     * selector returns (ast node definition, data reference) => value
+     */
+    decoder: createLeaf(
+      ["/views/scopes/inlined", "/next"],
+
+      (scopes, state) => {
+        let {stack, memory, storage} = state;
+
+        return (definition, ref) => decode(definition, ref, state, scopes)
+      }
+    )
   },
 
   /**
@@ -173,27 +188,22 @@ const data = createSelectorTree({
           "/views/scopes/inlined",
           "/proc/assignments",
           "/current/scope",
-          "/current/state"
+          "/views/decoder"
         ],
 
-        (scopes, assignments, scope, state) => {
-          let { stack, memory, storage } = state;
+        (scopes, assignments, scope, decode) => {
           let cur = scope.id;
           let variables = {};
 
-
           const format = (v) => {
             let definition = v.definition;
-            debug("assignments %O", assignments);
-            debug("v.id %o", v.id);
-            let assignment = (assignments[v.id] || {}).ref;
+            let ref = (assignments[v.id] || {}).ref;
 
-            debug("assignment: %o", assignment);
-            if (!assignment) {
+            if (!ref) {
               return undefined;
             }
 
-            return decode(definition, assignment, state, scopes);
+            return decode(definition, ref);
           };
 
           do {
@@ -219,6 +229,7 @@ const data = createSelectorTree({
    * data.next
    */
   next: {
+
     /**
      * data.next.state
      */

--- a/lib/data/selectors/index.js
+++ b/lib/data/selectors/index.js
@@ -13,24 +13,6 @@ import * as decodeUtils from "../decode/utils";
 
 import { BigNumber } from "bignumber.js";
 
-function cleanBigNumbers(value) {
-  if (BigNumber.isBigNumber(value)) {
-    return value.toNumber();
-
-  } else if (value && value.map != undefined) {
-    return value.map( (inner) => cleanBigNumbers(inner) );
-
-  } else if (value && typeof value == "object") {
-    return Object.assign(
-      {}, ...Object.entries(value)
-        .map( ([key, inner]) => ({ [key]: cleanBigNumbers(inner) }) )
-    );
-
-  } else {
-    return value;
-  }
-}
-
 function createStateSelectors({ stack, memory, storage }) {
   return {
     /**
@@ -221,7 +203,7 @@ const data = createSelectorTree({
         }
       ),
 
-      native: createLeaf(['./_'], cleanBigNumbers)
+      native: createLeaf(['./_'], decodeUtils.cleanBigNumbers)
     }
   },
 

--- a/test/ast.js
+++ b/test/ast.js
@@ -14,40 +14,6 @@ import solidity from "lib/solidity/selectors";
 
 import { getRange, findRange, rangeNodes } from "lib/ast/map";
 
-const __STORAGE = `
-pragma solidity ^0.4.18;
-
-contract Storage {
-  uint storedUint;
-  bytes32 storedBytes;
-  string storedString;
-
-  function setUint(uint x) public {
-    storedUint = x;
-  }
-
-  function getUint() public view returns (uint256) {
-    return storedUint;
-  }
-
-  function setBytes(bytes32 x) public {
-    storedBytes = x;
-  }
-
-  function getBytes() public view returns (bytes32) {
-    return storedBytes;
-  }
-
-  function setString(string x) public {
-    storedString = x;
-  }
-
-  function getString() public view returns (string) {
-    return storedString;
-  }
-}
-`;
-
 const __VARIABLES = `
 pragma solidity ^0.4.18;
 
@@ -79,8 +45,7 @@ contract Variables {
 
 
 let sources = {
-  "Variables.sol": __VARIABLES,
-  "Storage.sol": __STORAGE,
+  "Variables.sol": __VARIABLES
 }
 
 describe("AST", function() {
@@ -144,100 +109,6 @@ describe("AST", function() {
         session.stepNext();
       } while(!session.finished);
 
-    });
-  });
-
-  describe("Storage Assignment", function() {
-    it.skip("understands uints", async function() {
-      this.timeout(0);
-      let instance = await abstractions.Storage.deployed();
-
-      // first, increment
-      let receipt = await instance.setUint(102);
-      let txHash = receipt.tx;
-
-      let bugger = await Debugger.forTx(txHash, {
-        provider,
-        files,
-        contracts: artifacts
-      });
-
-      let session = bugger.connect();
-
-      do {
-        session.stepNext();
-      } while (!session.finished);
-
-      let expected = (await instance.getUint()).toNumber();
-      let actual = session.state
-        .ast
-        .storage[abstractions.Storage.deployedBinary]
-        .storedUint;
-
-      assert.equal(expected, actual);
-    });
-
-    it.skip("understands bytes32s", async function() {
-      this.timeout(0);
-      let instance = await abstractions.Storage.deployed();
-
-      // first, increment
-      let receipt = await instance.setBytes("hello");
-      let txHash = receipt.tx;
-
-      let bugger = await Debugger.forTx(txHash, {
-        provider,
-        files,
-        contracts: artifacts
-      });
-
-      let session = bugger.connect();
-
-      do {
-        session.stepNext();
-      } while (!session.finished);
-
-      let expected = await instance.getBytes();
-
-      let actual = session.state
-        .ast
-        .storage[abstractions.Storage.deployedBinary]
-        .storedBytes;
-
-      assert.equal(expected, actual);
-    });
-
-    it.skip("understands strings", async function() {
-      this.timeout(0);
-      let instance = await abstractions.Storage.deployed();
-
-      // first, increment
-      let receipt = await instance.setString(
-        "hello I am a string of word length at least 2"
-      );
-      let txHash = receipt.tx;
-
-      let bugger = await Debugger.forTx(txHash, {
-        provider,
-        files,
-        contracts: artifacts
-      });
-
-      let session = bugger.connect();
-      debug("ast: %O", session.view(ast.current.tree));
-
-      do {
-        session.stepNext();
-      } while (!session.finished);
-
-      let expected = await instance.getString();
-
-      let actual = session.state
-        .ast
-        .storage[abstractions.Storage.deployedBinary]
-        .storedString;
-
-      assert.equal(expected, actual);
     });
   });
 });

--- a/test/data/decode/decoding.js
+++ b/test/data/decode/decoding.js
@@ -1,0 +1,151 @@
+import debugModule from "debug";
+const debug = debugModule("test:data:decode");
+
+import { assert } from "chai";
+import Ganache from "ganache-cli";
+import Web3 from "web3";
+import util from "util";
+
+import { prepareContracts } from "test/helpers";
+
+import Debugger from "lib/debugger";
+
+import data from "lib/data/selectors";
+import ast from "lib/ast/selectors";
+
+const __STORAGE = `pragma solidity ^0.4.18;
+
+contract StorageVars {
+  event Ran();
+
+  uint[] multipleFullWordArray;  // length 3, will take up 3 words
+  uint16[] withinWordArray;  // length 10, will take up >1/2 word
+  uint64[] multiplePartWordArray; // length 9, will take up 2.25 words
+
+  uint240[] inconvenientlyWordOffsetArray; // length 3, takes 3.2 words
+
+  function run() public {
+    uint start = 1;
+    uint i;
+
+    for (i = 0; i < 3; i++) {
+      multipleFullWordArray.push(start + i);
+    }
+    start = i;
+
+    for (i = 0; i < 10; i++) {
+      withinWordArray.push(uint16(start + i));
+    }
+    start = i;
+
+    for (i = 0; i < 9; i++) {
+      multiplePartWordArray.push(uint64(start + i));
+    }
+    start = i;
+
+    for (i = 0; i < 3; i++) {
+      inconvenientlyWordOffsetArray.push(uint240(start + i));
+    }
+    start = i;
+
+    Ran();
+  }
+}
+`;
+
+function imitateRun() {
+  let multipleFullWordArray = [];
+  let withinWordArray = [];
+  let multiplePartWordArray = [];
+  let inconvenientlyWordOffsetArray = [];
+
+  let start = 1;
+  let i;
+
+  for (i = 0; i < 3; i++) {
+    multipleFullWordArray.push(start + i);
+  }
+  start = i;
+
+  for (i = 0; i < 10; i++) {
+    withinWordArray.push(start + i);
+  }
+  start = i;
+
+  for (i = 0; i < 9; i++) {
+    multiplePartWordArray.push(start + i);
+  }
+  start = i;
+
+  for (i = 0; i < 3; i++) {
+    inconvenientlyWordOffsetArray.push(start + i);
+  }
+
+  return {
+    multipleFullWordArray,
+    withinWordArray,
+    multiplePartWordArray,
+    inconvenientlyWordOffsetArray
+  }
+
+}
+
+const sources = {
+  "StorageVars.sol": __STORAGE,
+}
+
+describe("Data Decoding", function() {
+  var provider;
+  var web3;
+
+  var abstractions;
+  var artifacts;
+  var files;
+  var actualValues;
+
+  before("Create Provider", async function() {
+    provider = Ganache.provider({seed: "debugger", gasLimit: 7000000});
+    web3 = new Web3(provider);
+  });
+
+  before("Prepare contracts and artifacts", async function() {
+    this.timeout(30000);
+
+    let prepared = await prepareContracts(provider, sources)
+    abstractions = prepared.abstractions;
+    artifacts = prepared.artifacts;
+    files = prepared.files;
+  });
+
+  before("Run transaction, save decoded variable values", async function() {
+    this.timeout(30000);
+
+    let instance = await abstractions.StorageVars.deployed();
+    let receipt = await instance.run();
+    let txHash = receipt.tx;
+
+    let bugger = await Debugger.forTx(txHash, {
+      provider,
+      files,
+      contracts: artifacts
+    });
+
+    let session = bugger.connect();
+    var stepped;  // session steppers return false when done
+
+    let breakpoint = { address: instance.address, line: 35 };
+
+    session.continueUntil(breakpoint);
+
+    actualValues = session.view(data.identifiers.native.current);
+  });
+
+  for (let [identifier, expected] of Object.entries(imitateRun())) {
+    it(`correctly decodes ${identifier}`, function() {
+      let actual = actualValues[identifier];
+
+      assert.deepEqual(actual, expected);
+    });
+  }
+
+});

--- a/test/data/decode/decoding.js
+++ b/test/data/decode/decoding.js
@@ -106,7 +106,7 @@ const sources = {
   "StorageVars.sol": __STORAGE,
 }
 
-describe.skip("Data Decoding", function() {
+describe("Data Decoding", function() {
   var provider;
   var web3;
 

--- a/test/data/decode/decoding.js
+++ b/test/data/decode/decoding.js
@@ -20,15 +20,21 @@ const __STORAGE = `pragma solidity ^0.4.18;
 contract StorageVars {
   event Ran();
 
+  string shortString;
+  string longString;
+
   uint[] multipleFullWordArray;  // length 3, will take up 3 words
   uint16[] withinWordArray;  // length 10, will take up >1/2 word
   uint64[] multiplePartWordArray; // length 9, will take up 2.25 words
 
-  uint240[] inconvenientlyWordOffsetArray; // length 3, takes 3.2 words
+  uint240[] inconvenientlyWordOffsetArray; // length 3, takes ~2.8 words
 
   function run() public {
     uint start = 1;
     uint i;
+
+    shortString = "hello world";
+    longString = "solidity storage is a fun lesson in endianness";
 
     for (i = 0; i < 3; i++) {
       multipleFullWordArray.push(start + i);
@@ -60,6 +66,8 @@ function imitateRun() {
   let withinWordArray = [];
   let multiplePartWordArray = [];
   let inconvenientlyWordOffsetArray = [];
+  let shortString = "hello world";
+  let longString = "solidity storage is a fun lesson in endianness";
 
   let start = 1;
   let i;
@@ -84,6 +92,8 @@ function imitateRun() {
   }
 
   return {
+    shortString,
+    longString,
     multipleFullWordArray,
     withinWordArray,
     multiplePartWordArray,
@@ -137,7 +147,7 @@ describe.skip("Data Decoding", function() {
     let session = bugger.connect();
     var stepped;  // session steppers return false when done
 
-    let breakpoint = { address: instance.address, line: 35 };
+    let breakpoint = { address: instance.address, line: 41 };
 
     session.continueUntil(breakpoint);
 


### PR DESCRIPTION
Ref: #66 

- Add selector `data.views.decoder`, which returns a function `(definition, ref) => value`, to allow lookup of arbitrary data references with arbitrary AST nodes.

- Divide `data.current.identifiers` into a bunch of separately useful selectors:
  - `data.current.identifiers.definitions` which gives the AST definitions for current identifiers
  - `data.current.identifiers.refs` which gives the raw reference values (e.g. `{stack: 2}`) for current identifiers
  - `data.current.identifiers.decoded` renamed from `data.current.identifiers._`

- Rewrite reading from storage and parts of storage dereferencing to fix array child indexing and hopefully make things a bit clearer.

- Add integration tests for data decoding