### PR TITLE
Refactor data decoding tests to be data-driven

### DIFF
--- a/test/data/decode/helpers.js
+++ b/test/data/decode/helpers.js
@@ -1,0 +1,47 @@
+import debugModule from "debug";
+const debug = debugModule("test:data:decode:helpers");
+
+import { assert } from "chai";
+
+export function *generateUints() {
+  let x = 0;
+  while (true) {
+    yield x;
+    x++;
+  }
+}
+
+export function solidityForFixtures(testName, fixtures) {
+  return `pragma solidity ^0.4.23;
+
+contract ${testName} {
+
+  event Done();
+
+  // declarations
+  ${fixtures
+    .map( ({type, name}) => `${type} ${name};` )
+    .join("\n  ")}
+
+  function run() public {
+    ${fixtures
+      .map( ({name, value}) => `${name} = ${JSON.stringify(value)};` )
+      .join("\n    ")}
+
+    emit Done();
+  }
+}
+`;
+}
+
+export function testCasesForFixtures(fixtures) {
+  for (let { name, value: expected } of fixtures) {
+    it(`correctly decodes ${name}`, () => {
+      let definition = this.definitions[name];
+      let ref = this.refs[name];
+      let actual = this.decode(definition, ref);
+
+      assert.deepEqual(actual, expected);
+    });
+  }
+}


### PR DESCRIPTION
Generate the Solidity and expected values from something like...
```javascript
const FIXTURES = [{
  name: "multipleFullWordArray",
  type: "uint[]",
  value: generateArray(3)  // takes up 3 whole words
}, {
  name: "withinWordArray",
  type: "uint16[]",
  value: generateArray(10)  // takes up >1/2 word
}, {
  name: "multiplePartWordArray",
  type: "uint64[]",
  value: generateArray(9)  // takes up 2.25 words
}, {
  name: "inconvenientlyWordOffsetArray",
  type: "uint240[]",
  value: generateArray(3)  // takes up ~2.8 words
}, {
  name: "shortString",
  type: "string",
  value: "hello world"
}, {
  name: "longString",
  type: "string",
  value: "solidity storage is a fun lesson in endianness"
}];
```